### PR TITLE
Removing InstanceMethods

### DIFF
--- a/lib/attachment_magick.rb
+++ b/lib/attachment_magick.rb
@@ -84,9 +84,7 @@ module AttachmentMagick
     end
   end
 
-  module InstanceMethods
-    def image_cover
-      self.images.order(:priority).first
-    end
+  def image_cover
+    self.images.order(:priority).first
   end
 end


### PR DESCRIPTION
Removing InstanceMethods module inside of ActiveSupport::Concern because it is deprecated on ActiveSupport 3.2.0.
